### PR TITLE
Build with sources and javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,10 @@ dependencies {
     implementation("co.pvphub:ProtocolLibDsl:-SNAPSHOT")
     compileOnly("com.comphenix.protocol:ProtocolLib:4.7.0")
 }
-
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
This makes it so on the maven it publishes with javadocs and sources, allowing people to actually see the code & javadocs in their IDE