### PR TITLE
Fix LoreCycleButton erroring when theres no items at first.

### DIFF
--- a/src/main/kotlin/com/mattmx/ktgui/components/button/LoreCycleButton.kt
+++ b/src/main/kotlin/com/mattmx/ktgui/components/button/LoreCycleButton.kt
@@ -81,7 +81,7 @@ class LoreCycleButton(
     }
 
     fun getSelectedNum() : Int {
-        return selectableLores[selected]
+        return selectableLores.getOrNull(selected) ?: 0
     }
 
     fun lores() : MutableList<LoreEntry> {

--- a/src/main/kotlin/com/mattmx/ktgui/components/button/LoreCycleButton.kt
+++ b/src/main/kotlin/com/mattmx/ktgui/components/button/LoreCycleButton.kt
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack
 class LoreCycleButton(
     material: Material = Material.STONE,
     item: ItemStack? = null,
-    private var selected: Int = 0,
+    var selected: Int = 0,
     private var changed: ((LoreCycleButton, ButtonClickedEvent?) -> Unit)? = null,
     val lores: MutableList<LoreEntry> = mutableListOf()
 ) : GuiButton(material, item) {


### PR DESCRIPTION
Fixes `IndexOutOfBoundsException` when theres no items at first on a LoreCycleButton